### PR TITLE
Allowing addition/modification of tasks in taskwarrior, even when there is no internet connectivity

### DIFF
--- a/on-add.habitrpg.01.py
+++ b/on-add.habitrpg.01.py
@@ -20,10 +20,11 @@ def main():
 	id = pushTask(jsonTask)
 	if not id == "":
 		jsonTask["id_habitica"] = id
+		print "Task added on Habitica"
+	else:
+		print "Task was not added on Habitica"
 
 	print(json.dumps(jsonTask))
-
-	print "Task added on Habitica"
 
 def pushTask( jsonTask ):
 	values = {
@@ -35,10 +36,15 @@ def pushTask( jsonTask ):
 	if 'due' in jsonTask:
 		values["date"] = jsonTask["due"]
 
-	req = requests.post(URL + '/tasks/user', data=json.dumps(values), headers=headers)
+	try:
+		req = requests.post(URL + '/tasks/user', data=json.dumps(values), headers=headers, timeout=10)
+		jsonHabiticaTask = json.loads(req.text)
+		value = '';
+	except requests.ConnectTimeout:
+		print "Timeout while communicating with Habitica server!"
+	except requests.ConnectionError:
+		print "Connection error while communicating with Habitica server!"
 
-	jsonHabiticaTask = json.loads(req.text)
-	value = '';
 	try:
 		vError = jsonHabiticaTask["err"]
 		print "Error while pushing task to Habitica : " + vError

--- a/on-modify.habitrpg.01.py
+++ b/on-modify.habitrpg.01.py
@@ -18,24 +18,32 @@ headers = {
 def main():
 	jsonTaskOriginal = json.loads(sys.stdin.readline())
 	jsonTask = json.loads(sys.stdin.readline())
-			
+
 	if 'id_habitica' not in jsonTask or not jsonTask["status"] == "completed":
 		print json.dumps(jsonTask)
 		print "No task updated on Habitica"
 		return
-		
-	jsonOutput = copy.deepcopy(jsonTask)	
-	
-	pushTask(jsonOutput)
-	
-	print(json.dumps(jsonTask))
-		
-	print "Task completed on Habitica"
+
+	jsonOutput = copy.deepcopy(jsonTask)
+
+	if pushTask(jsonOutput):
+		print(json.dumps(jsonTask))
+		print "Task completed on Habitica"
+	else:
+		print(json.dumps(jsonTaskOriginal))
+		print "Task was not completed on Habitica"
 
 def pushTask( jsonOutput ):
-	req = requests.post(URL + '/tasks/' + jsonOutput["id_habitica"] + '/score/up', headers=headers)
-		
-	jsonHabiticaTask = json.loads(req.text)
-	
+	try:
+		req = requests.post(URL + '/tasks/' + jsonOutput["id_habitica"] + '/score/up', headers=headers, timeout=10)
+		jsonHabiticaTask = json.loads(req.text)
+		return 1
+	except requests.ConnectTimeout:
+		print "Timeout while communicating with Habitica server!"
+		return 0
+	except requests.ConnectionError:
+		print "Connection error while communicating with Habitica server!"
+		return 0
+
 main()
 sys.exit(0)

--- a/on-modify.habitrpg.01.py
+++ b/on-modify.habitrpg.01.py
@@ -27,11 +27,11 @@ def main():
 	jsonOutput = copy.deepcopy(jsonTask)
 
 	if pushTask(jsonOutput):
-		print(json.dumps(jsonTask))
 		print "Task completed on Habitica"
 	else:
-		print(json.dumps(jsonTaskOriginal))
 		print "Task was not completed on Habitica"
+
+	print json.dumps(jsonTask)
 
 def pushTask( jsonOutput ):
 	try:


### PR DESCRIPTION
As described in #6 , the current hook fails if it cannot connect to the habitica server. Since the hook fails, takswarrior is not saving the changes of the task, making it unusable when there is no internet connectivity.

These two commits fix this problem, by allowing the use of taskwarrior when there is no connectivity, or when the habitica server is down.