### PR TITLE
Add support for non-default difficulties

### DIFF
--- a/on-add.habitrpg.01.py
+++ b/on-add.habitrpg.01.py
@@ -33,8 +33,18 @@ def pushTask( jsonTask ):
 		"notes" : "Created from Taskwarrior"
 		}
 
+	priorityMap = {
+		"trivial": .1,
+		"easy": 1,
+		"medium": 1.5,
+		"hard": 2
+	}
+
 	if 'due' in jsonTask:
 		values["date"] = jsonTask["due"]
+
+	if 'difficulty' in jsonTask and jsonTask["difficulty"] in priorityMap:
+		values["difficulty"] = priorityMap[jsonTask["difficulty"]]
 
 	try:
 		req = requests.post(URL + '/tasks/user', data=json.dumps(values), headers=headers, timeout=10)


### PR DESCRIPTION
Allow users to provide a task UDA named "difficulty" with a value of "trivial",
"easy", "medium", or "hard" to set the habitica task's priority. Unsure why
the habitica API calls it priority when the text descriptors map to difficulty.